### PR TITLE
Remove error in spec

### DIFF
--- a/spec/questions_spec.rb
+++ b/spec/questions_spec.rb
@@ -191,8 +191,8 @@ describe 'bonus questions' do
   end
 
   it 'your_birthday_is_on_a_friday_in_the_year' do
-    n = your_birthday_is_on_a_friday_in_the_year(Time.new(2018, 1, 1))
-    expect(n).to eq 2020
+    n = your_birthday_is_on_a_friday_in_the_year(Time.new(2019, 9, 20))
+    expect(n).to eq 2025
   end
 
   it 'word_count_a_file' do


### PR DESCRIPTION
The first day on 2020 isn't in fact a Friday. My replacement test also requires submissions to notice that leap years exist (two recent submissions went forward a year by adding a constant number of seconds, which lost them a day).